### PR TITLE
fix: do not consume request body unless explicitly requested

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -41,8 +41,19 @@ func RequestLogger(logger *slog.Logger, o *Options) func(http.Handler) http.Hand
 			logReqBody := o.LogRequestBody != nil && o.LogRequestBody(r)
 			logRespBody := o.LogResponseBody != nil && o.LogResponseBody(r)
 
+			var includeAdditionalAttrsReqBody bool
+			if o.LogAdditionalAttrs != nil {
+				if o.LogAdditionalAttrs.AdditionalAttrs != nil && o.LogAdditionalAttrs.IncludeRequestBody != nil {
+					includeAdditionalAttrsReqBody = o.LogAdditionalAttrs.IncludeRequestBody(r)
+				}
+			} else if o.LogExtraAttrs != nil {
+				includeAdditionalAttrsReqBody = true
+			}
+			hasReqBody := r.Body != nil && r.Body != http.NoBody
+			consumeBody := hasReqBody && (logReqBody || includeAdditionalAttrsReqBody)
+
 			var reqBody bytes.Buffer
-			if logReqBody || o.LogExtraAttrs != nil {
+			if consumeBody {
 				r.Body = io.NopCloser(io.TeeReader(r.Body, &reqBody))
 			}
 
@@ -142,7 +153,7 @@ func RequestLogger(logger *slog.Logger, o *Options) func(http.Handler) http.Hand
 					logAttrs = appendAttrs(logAttrs, slog.Any(ErrorKey, ErrClientAborted), slog.String(s.ErrorType, "ClientAborted"))
 				}
 
-				if logReqBody || o.LogExtraAttrs != nil {
+				if consumeBody {
 					// Ensure the request body is fully read if the underlying HTTP handler didn't do so.
 					n, _ := io.Copy(io.Discard, r.Body)
 					if n > 0 {
@@ -155,7 +166,15 @@ func RequestLogger(logger *slog.Logger, o *Options) func(http.Handler) http.Hand
 				if logRespBody {
 					logAttrs = appendAttrs(logAttrs, slog.String(s.ResponseBody, logBody(&respBody, ww.Header(), o)))
 				}
-				if o.LogExtraAttrs != nil {
+				if o.LogAdditionalAttrs != nil {
+					if o.LogAdditionalAttrs.AdditionalAttrs != nil {
+						logAttrs = appendAttrs(logAttrs, o.LogAdditionalAttrs.AdditionalAttrs(&LogDetails{
+							Request:        r,
+							RequestBody:    reqBody.String(),
+							ResponseStatus: statusCode,
+						})...)
+					}
+				} else if o.LogExtraAttrs != nil {
 					logAttrs = appendAttrs(logAttrs, o.LogExtraAttrs(r, reqBody.String(), statusCode)...)
 				}
 				logAttrs = appendAttrs(logAttrs, getAttrs(ctx)...)


### PR DESCRIPTION
Add a new option `LogAdditionalAttrs` and deprecates `LogExtraAttrs`:

1. Adds `LogAdditionalAttrsOptions.IncludeRequestBody` to provide control over when request body is consumed and passed to `LogAdditionalAttrsOptions.AdditionalAttrs`.  The default is `false` (vs. `LogExtraAttrs` which would always consume the entire body) which could lead to high memory usage even when not needed
2. Passes `LogDetails` to `LogAdditionalAttrsOptions.AdditionalAttrs` which contains the same params as `LogExtraAttrs` does but supports extending additional details if/when needed to avoid breaking changes moving forward

The approach taken is not a breaking change, however if desired, the implementation can be simplified which would result in a breaking change and a major bump.

Resolves #62